### PR TITLE
Force app into dark mode via plist

### DIFF
--- a/Multiplatform-Info.plist
+++ b/Multiplatform-Info.plist
@@ -23,5 +23,7 @@
 		<key>UISceneConfigurations</key>
 		<dict/>
 	</dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Dark</string>
 </dict>
 </plist>

--- a/Multiplatform/LiveKitExample.swift
+++ b/Multiplatform/LiveKitExample.swift
@@ -90,7 +90,6 @@ struct RoomContextView: View {
         RoomSwitchView()
             .environmentObject(roomCtx)
             .environmentObject(roomCtx.room)
-            .environment(\.colorScheme, .dark)
             .foregroundColor(Color.white)
             .onDisappear {
                 print("\(String(describing: type(of: self))) onDisappear")

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -73,5 +73,7 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Dark</string>
 </dict>
 </plist>


### PR DESCRIPTION
there were a handful of broken screens like PublishOptionsView due to platform inconsistencies with how colorScheme is applied. plist is more comprehensive