### PR TITLE
Use default format for identifiers

### DIFF
--- a/LiveKitExample.xcodeproj/project.pbxproj
+++ b/LiveKitExample.xcodeproj/project.pbxproj
@@ -390,7 +390,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 2.0.19;
-				PRODUCT_BUNDLE_IDENTIFIER = io.livekit.example.SwiftSDK.1.BroadcastExt;
+				PRODUCT_BUNDLE_IDENTIFIER = io.livekit.example.SwiftSDK.1.broadcast;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = NO;
 				SDKROOT = iphoneos;
@@ -420,7 +420,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 2.0.19;
-				PRODUCT_BUNDLE_IDENTIFIER = io.livekit.example.SwiftSDK.1.BroadcastExt;
+				PRODUCT_BUNDLE_IDENTIFIER = io.livekit.example.SwiftSDK.1.broadcast;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = NO;
 				SDKROOT = iphoneos;

--- a/Multiplatform-Info.plist
+++ b/Multiplatform-Info.plist
@@ -10,10 +10,6 @@
 	<string>Please allow for main camera access</string>
 	<key>NSWorldSensingUsageDescription</key>
 	<string>Please allow for main camera access</string>
-	<key>RTCAppGroupIdentifier</key>
-	<string>group.io.livekit.example.SwiftSDK.1</string>
-	<key>RTCScreenSharingExtension</key>
-	<string>io.livekit.example.SwiftSDK.1.BroadcastExt</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationPreferredDefaultSceneSessionRole</key>

--- a/iOS/BroadcastExt/Info.plist
+++ b/iOS/BroadcastExt/Info.plist
@@ -29,7 +29,9 @@
 		<key>RPBroadcastProcessMode</key>
 		<string>RPBroadcastProcessModeSampleBuffer</string>
 	</dict>
+    <!-- No longer required by default; see iOS screen sharing docs
 	<key>RTCAppGroupIdentifier</key>
 	<string>group.io.livekit.example.SwiftSDK.1</string>
+    -->
 </dict>
 </plist>

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -44,10 +44,12 @@
 	<string>Keychain is used to store all preferences.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>uses your microphone for video chat</string>
+    <!-- No longer required by default; see iOS screen sharing docs
 	<key>RTCAppGroupIdentifier</key>
 	<string>group.io.livekit.example.SwiftSDK.1</string>
 	<key>RTCScreenSharingExtension</key>
-	<string>io.livekit.example.SwiftSDK.1.BroadcastExt</string>
+	<string>io.livekit.example.SwiftSDK.1.broadcast</string>
+    -->
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
- Use the default format for identifiers introduced in livekit/client-sdk-swift#573