### PR TITLE
Fix broadcast extension id

### DIFF
--- a/iOS/BroadcastExt/Info.plist
+++ b/iOS/BroadcastExt/Info.plist
@@ -20,6 +20,10 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>RTCAppGroupIdentifier</key>
+	<string>group.io.livekit.example.SwiftSDK.1</string>
+	<key>RTCScreenSharingExtension</key>
+	<string>io.livekit.example.SwiftSDK.1.broadcast-ext</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
Before testing, double-check your publishing permissions and/or reinstall the app.